### PR TITLE
Fix for strict alignment warnings

### DIFF
--- a/include/vectormath/SSE/cpp/boolInVec.h
+++ b/include/vectormath/SSE/cpp/boolInVec.h
@@ -135,11 +135,21 @@ boolInVec::boolInVec(const floatInVec &vec)
     *this = (vec != floatInVec(0.0f));
 }
 
+union boolInVec_converter
+{
+    __m128 m128;
+    bool b;
+    float f;
+    int i;
+    boolInVec_converter(int i) : i(i) {}
+    boolInVec_converter(__m128 m128) : m128(m128) {}
+    boolInVec_converter() {}
+};
+
 inline
 boolInVec::boolInVec(bool scalar)
 {
-    unsigned int mask = -(int)scalar;
-	mData = _mm_set1_ps(*(float *)&mask); // TODO: Union
+    mData = _mm_set1_ps(boolInVec_converter(-(int)scalar).f);
 }
 
 #ifdef _VECTORMATH_NO_SCALAR_CAST
@@ -151,7 +161,7 @@ inline
 boolInVec::operator bool() const
 #endif
 {
-	return *(bool *)&mData;
+    return boolInVec_converter(mData).b;
 }
 
 inline

--- a/include/vectormath/SSE/cpp/vectormath_aos.h
+++ b/include/vectormath/SSE/cpp/vectormath_aos.h
@@ -95,6 +95,15 @@ union SSEFloat
 	SSEFloat() {}//uninitialized
 };
 
+union scalar_converter
+{
+    unsigned int ui;
+    float f;
+    scalar_converter(unsigned int ui) : ui(ui) {}
+    scalar_converter(float f) : f(f) {}
+    scalar_converter() {}
+};
+
 static VECTORMATH_FORCE_INLINE __m128 vec_sel(__m128 a, __m128 b, __m128 mask)
 {
 	return _mm_or_ps(_mm_and_ps(mask, b), _mm_andnot_ps(mask, a));
@@ -105,12 +114,12 @@ static VECTORMATH_FORCE_INLINE __m128 vec_sel(__m128 a, __m128 b, const unsigned
 }
 static VECTORMATH_FORCE_INLINE __m128 vec_sel(__m128 a, __m128 b, unsigned int _mask)
 {
-	return vec_sel(a, b, _mm_set1_ps(*(float *)&_mask));
+        return vec_sel(a, b, _mm_set1_ps(scalar_converter(_mask).f));
 }
 
 static VECTORMATH_FORCE_INLINE __m128 toM128(unsigned int x)
 {
-    return _mm_set1_ps( *(float *)&x );
+    return _mm_set1_ps(scalar_converter(x).f);
 }
 
 static VECTORMATH_FORCE_INLINE __m128 fabsf4(__m128 x)


### PR DESCRIPTION
This is the fix for strict alignment warnings that are emitted with gcc 4.4.3 on ubuntu 10.04 x86_64
